### PR TITLE
Remove show_progress_bar = True

### DIFF
--- a/llm2vec/llm2vec.py
+++ b/llm2vec/llm2vec.py
@@ -277,7 +277,6 @@ class LLM2Vec(nn.Module):
         sentences = concatenated_input_texts
 
         self.eval()
-        show_progress_bar = True
 
         if convert_to_tensor:
             convert_to_numpy = False


### PR DESCRIPTION
Progress bar is always enabled because of this line regardless of the `show_progress_bar` option.