### PR TITLE
fix accuracy metric

### DIFF
--- a/experiments/run_mntp.py
+++ b/experiments/run_mntp.py
@@ -867,6 +867,8 @@ def main():
 
         def compute_metrics(eval_preds):
             preds, labels = eval_preds
+            preds = preds[:, :-1]
+            labels = labels[:, 1:]
             # preds have the same shape as the labels, after the argmax(-1) has been calculated
             # by preprocess_logits_for_metrics
             labels = labels.reshape(-1)


### PR DESCRIPTION
Unlike MLM, when learning MNTP, accuracy must be calculated based on the preds in front of the MASK TOKEN, but the current code is based on MLM. (Calculating results and accuracy of MASK TOKEN position)

I modified `preds` and `labels` to be calculated correctly by shifting them.
The original code continues to decrease eval_accuracy, but the modified code correctly improves eval_accuracy.