### PR TITLE
Prevent splitting of ModifiedMistralDecoderLayers

### DIFF
--- a/llm2vec/models/bidirectional_llama.py
+++ b/llm2vec/models/bidirectional_llama.py
@@ -83,6 +83,8 @@ class ModifiedLlamaDecoderLayer(LlamaDecoderLayer):
 
 
 class LlamaBiModel(LlamaModel):
+    _no_split_modules = ["ModifiedLlamaDecoderLayer"]
+
     def __init__(self, config: LlamaConfig):
         if not is_transformers_attn_greater_or_equal_4_38():
             raise ValueError(

--- a/llm2vec/models/bidirectional_mistral.py
+++ b/llm2vec/models/bidirectional_mistral.py
@@ -73,6 +73,8 @@ class ModifiedMistralDecoderLayer(MistralDecoderLayer):
 
 
 class MistralBiModel(MistralModel):
+    _no_split_modules = ["ModifiedMistralDecoderLayer"]
+
     def __init__(self, config: MistralConfig):
         MistralPreTrainedModel.__init__(self, config)
         self.padding_idx = config.pad_token_id


### PR DESCRIPTION
Previously the layers could be split across devices, e.g. when using `device_map='auto'`. This would result errors like this one:

```
RuntimeError:
Expected all tensors to be on the same device,
but found at least two devices, cuda:0 and cuda:1!
```

The remote code I got from huggingface has a different name `MistralEncoderModel` rather than `MistralBiModel` but I assume that this is the correct file to change. I tested this in locally by editing the remote files in my `~/.cache/` directory.