### PR TITLE
The code on huggingface is incompatible with Github/PyPi llm2vec, specifically with the changes in the transformers module

### DIFF
--- a/llm2vec/models/bidirectional_gemma.py
+++ b/llm2vec/models/bidirectional_gemma.py
@@ -4,6 +4,7 @@ from packaging import version
 import importlib.metadata
 
 from transformers import GemmaModel, GemmaForCausalLM, GemmaPreTrainedModel, GemmaConfig
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.models.gemma.modeling_gemma import (
     GemmaDecoderLayer,
     GemmaAttention,
@@ -59,7 +60,8 @@ class ModifiedGemmaAttention(GemmaAttention):
 
 class ModifiedGemmaDecoderLayer(GemmaDecoderLayer):
     def __init__(self, config: GemmaConfig, layer_idx: int):
-        nn.Module.__init__(self)
+        GradientCheckpointingLayer.__init__(self)
+        # nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
         self.self_attn = ModifiedGemmaAttention(

--- a/llm2vec/models/bidirectional_gemma.py
+++ b/llm2vec/models/bidirectional_gemma.py
@@ -7,8 +7,6 @@ from transformers import GemmaModel, GemmaForCausalLM, GemmaPreTrainedModel, Gem
 from transformers.models.gemma.modeling_gemma import (
     GemmaDecoderLayer,
     GemmaAttention,
-    GemmaFlashAttention2,
-    GemmaSdpaAttention,
     GemmaMLP,
     GemmaRMSNorm,
 )
@@ -40,23 +38,23 @@ class ModifiedGemmaAttention(GemmaAttention):
         self.is_causal = False
 
 
-class ModifiedGemmaFlashAttention2(GemmaFlashAttention2):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedGemmaFlashAttention2(GemmaFlashAttention2):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-class ModifiedGemmaSdpaAttention(GemmaSdpaAttention):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedGemmaSdpaAttention(GemmaSdpaAttention):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-GEMMA_ATTENTION_CLASSES = {
-    "eager": ModifiedGemmaAttention,
-    "flash_attention_2": ModifiedGemmaFlashAttention2,
-    "sdpa": ModifiedGemmaSdpaAttention,
-}
+# GEMMA_ATTENTION_CLASSES = {
+#     "eager": ModifiedGemmaAttention,
+#     "flash_attention_2": ModifiedGemmaFlashAttention2,
+#     "sdpa": ModifiedGemmaSdpaAttention,
+# }
 
 
 class ModifiedGemmaDecoderLayer(GemmaDecoderLayer):
@@ -64,7 +62,7 @@ class ModifiedGemmaDecoderLayer(GemmaDecoderLayer):
         nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
-        self.self_attn = GEMMA_ATTENTION_CLASSES[config._attn_implementation](
+        self.self_attn = ModifiedGemmaAttention(
             config=config, layer_idx=layer_idx
         )
 

--- a/llm2vec/models/bidirectional_llama.py
+++ b/llm2vec/models/bidirectional_llama.py
@@ -1,5 +1,6 @@
 import torch
 
+from packaging import version
 from transformers import LlamaModel, LlamaForCausalLM, LlamaPreTrainedModel, LlamaConfig
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer,
@@ -8,7 +9,7 @@ from transformers.models.llama.modeling_llama import (
     LlamaRMSNorm,
     LlamaRotaryEmbedding,
 )
-
+from transformers.modeling_layers import GradientCheckpointingLayer
 from torch import nn
 from transformers.utils import logging
 from transformers.cache_utils import Cache, StaticCache
@@ -48,7 +49,8 @@ class ModifiedLlamaAttention(LlamaAttention):
 
 class ModifiedLlamaDecoderLayer(LlamaDecoderLayer):
     def __init__(self, config: LlamaConfig, layer_idx: int):
-        nn.Module.__init__(self)
+        GradientCheckpointingLayer.__init__(self)
+        # nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
         self.self_attn = ModifiedLlamaAttention(

--- a/llm2vec/models/bidirectional_llama.py
+++ b/llm2vec/models/bidirectional_llama.py
@@ -4,8 +4,6 @@ from transformers import LlamaModel, LlamaForCausalLM, LlamaPreTrainedModel, Lla
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer,
     LlamaAttention,
-    LlamaFlashAttention2,
-    LlamaSdpaAttention,
     LlamaMLP,
     LlamaRMSNorm,
     LlamaRotaryEmbedding,
@@ -29,23 +27,23 @@ class ModifiedLlamaAttention(LlamaAttention):
         self.is_causal = False
 
 
-class ModifiedLlamaFlashAttention2(LlamaFlashAttention2):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedLlamaFlashAttention2(LlamaFlashAttention2):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-class ModifiedLlamaSdpaAttention(LlamaSdpaAttention):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedLlamaSdpaAttention(LlamaSdpaAttention):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-LLAMA_ATTENTION_CLASSES = {
-    "eager": ModifiedLlamaAttention,
-    "flash_attention_2": ModifiedLlamaFlashAttention2,
-    "sdpa": ModifiedLlamaSdpaAttention,
-}
+# LLAMA_ATTENTION_CLASSES = {
+#     "eager": ModifiedLlamaAttention,
+#     "flash_attention_2": ModifiedLlamaFlashAttention2,
+#     "sdpa": ModifiedLlamaSdpaAttention,
+# }
 
 
 class ModifiedLlamaDecoderLayer(LlamaDecoderLayer):
@@ -53,7 +51,7 @@ class ModifiedLlamaDecoderLayer(LlamaDecoderLayer):
         nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
-        self.self_attn = LLAMA_ATTENTION_CLASSES[config._attn_implementation](
+        self.self_attn = ModifiedLlamaAttention(
             config=config, layer_idx=layer_idx
         )
 

--- a/llm2vec/models/bidirectional_mistral.py
+++ b/llm2vec/models/bidirectional_mistral.py
@@ -6,6 +6,7 @@ from transformers import (
     MistralForCausalLM,
     MistralConfig,
 )
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.models.mistral.modeling_mistral import (
     MistralDecoderLayer,
     MistralRMSNorm,
@@ -51,7 +52,8 @@ class ModifiedMistralAttention(MistralAttention):
 
 class ModifiedMistralDecoderLayer(MistralDecoderLayer):
     def __init__(self, config: MistralConfig, layer_idx: int):
-        nn.Module.__init__(self)
+        GradientCheckpointingLayer.__init__(self)
+        # nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
         self.self_attn = ModifiedMistralAttention(

--- a/llm2vec/models/bidirectional_mistral.py
+++ b/llm2vec/models/bidirectional_mistral.py
@@ -10,8 +10,6 @@ from transformers.models.mistral.modeling_mistral import (
     MistralDecoderLayer,
     MistralRMSNorm,
     MistralAttention,
-    MistralFlashAttention2,
-    MistralSdpaAttention,
     MistralMLP,
 )
 from torch import nn
@@ -32,23 +30,23 @@ class ModifiedMistralAttention(MistralAttention):
         self.is_causal = False
 
 
-class ModifiedMistralFlashAttention2(MistralFlashAttention2):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedMistralFlashAttention2(MistralFlashAttention2):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-class ModifiedMistralSdpaAttention(MistralSdpaAttention):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedMistralSdpaAttention(MistralSdpaAttention):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-MISTRAL_ATTENTION_CLASSES = {
-    "eager": ModifiedMistralAttention,
-    "flash_attention_2": ModifiedMistralFlashAttention2,
-    "sdpa": ModifiedMistralSdpaAttention,
-}
+# MISTRAL_ATTENTION_CLASSES = {
+#     "eager": ModifiedMistralAttention,
+#     "flash_attention_2": ModifiedMistralFlashAttention2,
+#     "sdpa": ModifiedMistralSdpaAttention,
+# }
 
 
 class ModifiedMistralDecoderLayer(MistralDecoderLayer):
@@ -56,7 +54,7 @@ class ModifiedMistralDecoderLayer(MistralDecoderLayer):
         nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
-        self.self_attn = MISTRAL_ATTENTION_CLASSES[config._attn_implementation](
+        self.self_attn = ModifiedMistralAttention(
             config, layer_idx
         )
 

--- a/llm2vec/models/bidirectional_qwen2.py
+++ b/llm2vec/models/bidirectional_qwen2.py
@@ -8,8 +8,6 @@ from transformers.models.qwen2.modeling_qwen2 import (
     Qwen2DecoderLayer,
     Qwen2RMSNorm,
     Qwen2Attention,
-    Qwen2FlashAttention2,
-    Qwen2SdpaAttention,
     Qwen2MLP,
 )
 from torch import nn
@@ -30,23 +28,23 @@ class ModifiedQwen2Attention(Qwen2Attention):
         self.is_causal = False
 
 
-class ModifiedQwen2FlashAttention2(Qwen2FlashAttention2):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedQwen2FlashAttention2(Qwen2FlashAttention2):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-class ModifiedQwen2SdpaAttention(Qwen2SdpaAttention):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.is_causal = False
+# class ModifiedQwen2SdpaAttention(Qwen2SdpaAttention):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.is_causal = False
 
 
-QWEN2_ATTENTION_CLASSES = {
-    "eager": ModifiedQwen2Attention,
-    "flash_attention_2": ModifiedQwen2FlashAttention2,
-    "sdpa": ModifiedQwen2SdpaAttention,
-}
+# QWEN2_ATTENTION_CLASSES = {
+#     "eager": ModifiedQwen2Attention,
+#     "flash_attention_2": ModifiedQwen2FlashAttention2,
+#     "sdpa": ModifiedQwen2SdpaAttention,
+# }
 
 
 class ModifiedQwen2DecoderLayer(Qwen2DecoderLayer):
@@ -54,7 +52,7 @@ class ModifiedQwen2DecoderLayer(Qwen2DecoderLayer):
         nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
-        self.self_attn = QWEN2_ATTENTION_CLASSES[config._attn_implementation](
+        self.self_attn = ModifiedQwen2Attention(
             config=config, layer_idx=layer_idx
         )
 

--- a/llm2vec/models/bidirectional_qwen2.py
+++ b/llm2vec/models/bidirectional_qwen2.py
@@ -1,7 +1,9 @@
 from typing import List, Optional, Tuple, Union
 import torch
+from packaging import version
 
 from transformers import Qwen2Model, Qwen2ForCausalLM, Qwen2PreTrainedModel, Qwen2Config
+from transformers.modeling_layers import GradientCheckpointingLayer
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.cache_utils import Cache, DynamicCache
 from transformers.models.qwen2.modeling_qwen2 import (
@@ -49,7 +51,8 @@ class ModifiedQwen2Attention(Qwen2Attention):
 
 class ModifiedQwen2DecoderLayer(Qwen2DecoderLayer):
     def __init__(self, config: Qwen2Config, layer_idx: int):
-        nn.Module.__init__(self)
+        GradientCheckpointingLayer.__init__(self)
+        # nn.Module.__init__(self)
         self.hidden_size = config.hidden_size
 
         self.self_attn = ModifiedQwen2Attention(

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "tqdm",
         "torch",
         "peft",
-        "transformers>=4.43.1,<=4.44.2",
+        "transformers>=4.43.1",
         "datasets",
         "evaluate",
         "scikit-learn",


### PR DESCRIPTION
As you all know from the changes you all made on Hugging Face to llm2vec encoder architecture, the transformers library has changed how it receives instruction on attention mechanisms.  However, while the changes on Hugging Face update llm2vec for the modern transformers library, the github llm2vec is left unchanged, making the supplied implementation code on both github and Hugging Face incompatible with your pretrained models, one of the reasons being requiring two different, incompatible versions of the transformers library.  While my changes try to  implement attention the way the modern transformers library does before I realized your group had already implemented these changes on Hugging Face, the changes are still necessary in order to use the llm2vec library with your trained models on Hugging Face, with the exception of the Mistral-based models.  However, the Mistral  models do function appropriately with these code changes.

I left some code alone with regards to causal masks that are whole scale deleted in the Hugging Face code, so it might be more appropriate to update llm2vec with your group's code from the Hugging Face repository.